### PR TITLE
Adding permission_callback line to register_rest_route function

### DIFF
--- a/includes/wp-rest-api-favicon-v2.php
+++ b/includes/wp-rest-api-favicon-v2.php
@@ -55,7 +55,8 @@ if ( ! class_exists( 'WP_REST_API_favicon' ) ) :
       register_rest_route( self::get_api_namespace(), '/favicon', array(
           array(
             'methods'  => WP_REST_Server::READABLE,
-            'callback' => array( $this, 'get_favicon' )
+            'callback' => array( $this, 'get_favicon' ),
+            'permission_callback' => function(){return true; },
           )
         )
       );


### PR DESCRIPTION
Adding permission_callback line to register_rest_route function to meet the requirements of Wordpress v5.5.0.